### PR TITLE
Fix various haddock issues

### DIFF
--- a/compiler/rename/RnTypes.hs
+++ b/compiler/rename/RnTypes.hs
@@ -848,11 +848,11 @@ bindLHsTyVarBndr doc mb_assoc kv_names tv_names hs_tv_bndr thing_inside
 
 bindImplicitKvs :: HsDocContext
                 -> Maybe a
-                -> [Located RdrName]  -- kind var *occurrences*, from which
+                -> [Located RdrName]  -- ^ kind var *occurrences*, from which
                                       -- intent to bind is inferred
-                -> NameSet            -- *type* variables, for type/kind
+                -> NameSet            -- ^ *type* variables, for type/kind
                                       -- misuse check for -XNoTypeInType
-                -> ([Name] -> RnM (b, FreeVars)) -- passed new kv_names
+                -> ([Name] -> RnM (b, FreeVars)) -- ^ passed new kv_names
                 -> RnM (b, FreeVars)
 bindImplicitKvs _   _        []       _        thing_inside = thing_inside []
 bindImplicitKvs doc mb_assoc free_kvs tv_names thing_inside
@@ -879,8 +879,8 @@ bindImplicitKvs doc mb_assoc free_kvs tv_names thing_inside
   where
       -- check to see if the variables free in a kind are bound as type
       -- variables. Assume -XNoTypeInType.
-    check_tv_used_in_kind :: NameSet       -- *type* variables
-                          -> Located Name  -- renamed var used in kind
+    check_tv_used_in_kind :: NameSet       -- ^ *type* variables
+                          -> Located Name  -- ^ renamed var used in kind
                           -> RnM ()
     check_tv_used_in_kind tv_names (L loc kv_name)
       = when (kv_name `elemNameSet` tv_names) $

--- a/compiler/typecheck/TcHsType.hs
+++ b/compiler/typecheck/TcHsType.hs
@@ -1593,9 +1593,9 @@ kcLookupKind nm
 -- See Note [Typechecking telescopes]
 splitTelescopeTvs :: Kind         -- of the head of the telescope
                   -> LHsQTyVars Name
-                  -> ( [TyVar]    -- *scoped* type variables
-                     , [TyVar]    -- *implicit* type variables (cases 1 & 2)
-                     , [TyVar]    -- *explicit* type variables (cases 3 & 4)
+                  -> ( [TyVar]    -- scoped type variables
+                     , [TyVar]    -- implicit type variables (cases 1 & 2)
+                     , [TyVar]    -- explicit type variables (cases 3 & 4)
                      , Kind )     -- result kind
 splitTelescopeTvs kind tvbs@(HsQTvs { hsq_implicit = hs_kvs
                                     , hsq_explicit = hs_tvs })

--- a/compiler/typecheck/TcUnify.hs
+++ b/compiler/typecheck/TcUnify.hs
@@ -542,11 +542,11 @@ tcInfer tc_check
 
 tcGen :: UserTypeCtxt -> TcType
       -> ([TcTyVar] -> TcRhoType -> TcM result)
-         -- thing_inside is passed only the *type* variables, not
+         -- ^ thing_inside is passed only the *type* variables, not
          -- *coercion* variables. They are only ever used for scoped type
          -- variables.
       -> TcM (HsWrapper, result)
-        -- The expression has type: spec_ty -> expected_ty
+         -- ^ The expression has type: spec_ty -> expected_ty
 
 tcGen ctxt expected_ty thing_inside
    -- We expect expected_ty to be a forall-type

--- a/compiler/types/TyCoRep.hs
+++ b/compiler/types/TyCoRep.hs
@@ -639,8 +639,9 @@ instance Outputable UnivCoProvenance where
 
 -- | A coercion to be filled in by the type-checker. See Note [Coercion holes]
 data CoercionHole
-  = CoercionHole Unique   -- ^ used only for debugging
-                 (IORef (Maybe Coercion))
+  = CoercionHole { chUnique   :: Unique   -- ^ used only for debugging
+                 , chCoercion ::(IORef (Maybe Coercion))
+                 }
   deriving (Data.Typeable)
 
 instance Data.Data CoercionHole where

--- a/compiler/types/Unify.hs
+++ b/compiler/types/Unify.hs
@@ -287,7 +287,7 @@ tcUnifyTyWithTFs twoWay t1 t2
       Unifiable  (subst, _) -> Just $ niFixTCvSubst subst
       MaybeApart (subst, _) -> Just $ niFixTCvSubst subst
       -- we want to *succeed* in questionable cases. This is a
-      -- *pre-unification* algorithm.
+      -- pre-unification algorithm.
       SurelyApart      -> Nothing
   where
     rn_env = mkRnEnv2 $ mkInScopeSet $ tyCoVarsOfTypes [t1, t2]


### PR DESCRIPTION
There are numerous instances where comments use haddock-like syntax yet
outside of a Haddock comment, resulting in parse errors when `haddock` is
run.

Feel free not to merge this; just felt it might be worthwhile to give you the option.
